### PR TITLE
Use path basename for Conf

### DIFF
--- a/source/cli.js
+++ b/source/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import process from 'node:process';
+import {basename} from 'node:path';
 import React from 'react';
 import {render, Box, Text, Newline, useInput} from 'ink';
 import SelectInputModule from 'ink-select-input';
@@ -31,6 +33,8 @@ const SelectInput = SelectInputModule.default;
 const Spinner = SpinnerModule.default;
 
 const config = new Conf({
+	projectName: basename(process.cwd()),
+	projectSuffix: 'switchbranchcli',
 	encryptionKey: 'thisistopsecret',
 	schema: {
 		accessToken: {


### PR DESCRIPTION
Fixes #3
Fixes #5

### How to reproduce

1. Enter the root path of your Git repository
2. Remove the `name` field from your `package.json` _(You can ignore this step if your project does not have `package.json`)_
3. Run `switch-branch`

### Root cause

The `Conf` we are using requires a [projectName](https://github.com/sindresorhus/conf#projectname) to create the config directory. But the `projectName` is obtained from `package.json`.

### Solution 1

We should specify the `projectName` manually for the current project.

The solution is to use `basename(process.cwd())` as `projectName

#### Question

But there will be a bug when the user has two different projects but with the same basename.

Maybe we can use the absolute path as its config directory name?

### Solution 2

Use `switch-branch-cli` as project name. And change the config storage method.

```js
const origin = await gitRemoteOriginUrl();
const config = Conf({
	projectName: 'switch-branch-cli',
	// ...
});

config.set(`${origin}-accessToken`, accessToken);
```